### PR TITLE
Improve training speed and add evaluation dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ __pycache__/
 *.pyzw
 *.pyzwz
 *.jsonl
+!data/eval_sample.jsonl
 *M.txt
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ Timeline:
 1. Create 5-10M param encoder-decoder model with no recurrency -- show that with high data quality, and modern transformer techniques, it can somewhat understand the english language and perform decently. This model should be trained locally on a single GPU, really showcasing the level of power the average consumer could get.
 2. Add recurrency to the model and show that it sees performance gains on major benchmarks, even if minor (shouldn't expect much with low param count)
 3. Scale params to 450M and train for 100B tokens, using every bit of free compute I've got available!
+
+## New Features
+
+- Added a tiny evaluation set at `data/eval_sample.jsonl` and hooked it into `train.py`. The trainer now reports
+  perplexity every few steps so you can monitor progress.
+- Training now enables `torch.compile` (when available) and sets high matmul precision on Apple Silicon for faster
+  execution on macOS machines.

--- a/data/eval_sample.jsonl
+++ b/data/eval_sample.jsonl
@@ -1,0 +1,3 @@
+{"text": "Hello world."}
+{"text": "How are you today?"}
+{"text": "This is a sample sentence for evaluation."}


### PR DESCRIPTION
## Summary
- provide small evaluation dataset
- compute perplexity during training
- enable `torch.compile` and higher matmul precision for better macOS MPS performance
- document new features
- allow evaluation dataset to be tracked in git

## Testing
- `python -m py_compile src/train.py components/basic_model.py components/layers.py components/attention.py src/data_collator_for_span.py`


------
https://chatgpt.com/codex/tasks/task_e_6866dba6ca74832c92d13960825b168e